### PR TITLE
SpeedBaal improvements

### DIFF
--- a/d2bs/kolbot/D2BotLead.dbj
+++ b/d2bs/kolbot/D2BotLead.dbj
@@ -233,11 +233,10 @@ function main() {
 	const Team = require('Team');
 	require('Config')();
 	while (!(HeartBeat.handle && Object.keys(HeartBeat.gameInfo).length)) delay(10);
-
 	Team.on('RequestGame', data => data.reply({
 			Follow: {
 				gameInfo: {
-					gameName: me.ingame && me.gamename.toLowerCase() || HeartBeat.gameInfo && HeartBeat.gameInfo.gameName && HeartBeat.gameInfo.gameName,
+					gameName: me.ingame && me.gamename.toLowerCase() || HeartBeat.gameInfo && HeartBeat.gameInfo.gameName && HeartBeat.gameInfo.gameName+gameCount,
 					gamePass: me.ingame && me.gamepassword.toLowerCase() || HeartBeat.gameInfo && HeartBeat.gameInfo.gamePass && HeartBeat.gameInfo.gamePass,
 					up: me.ingame,
 				}

--- a/d2bs/kolbot/D2BotTCPIP.dbj
+++ b/d2bs/kolbot/D2BotTCPIP.dbj
@@ -80,11 +80,11 @@ function main() {
 	});
 	LocationEvents.on(sdk.locations.Difficulty, function () {
 		switch (HeartBeat.gameInfo.difficulty) {
-			case 'normal':
+			case 'Normal':
 				return Control.NormalSP.click();
-			case 'nightmare':
+			case 'Nightmare':
 				return Control.NightmareSP.click();
-			case 'hell':
+			case 'Hell':
 				return Control.HellSP.click();
 			default: // highest
 				return [Control.HellSP, Control.NightmareSP, Control.NormalSP].filter(x => x.control)[0].click();

--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -5,6 +5,7 @@
 (function (module, require) {
 	const Misc = require('Misc');
 	const Pather = require('Pather');
+	const Config = require('Config');
 	const Diablo = function (Config, Attack, Pickit, _, Town) {
 		const Promise = require('Promise'),
 			TownPrecast = require('TownPrecast'),
@@ -72,14 +73,20 @@
 								}
 							} while (!boss);
 
-							return diaTick || !(Config.Diablo.Fast && Attack.kill(boss) || Attack.clear(40, 0, getLocaleString(locale), diaSort));
+							if (Config.Diablo.Fast) {
+								Attack.kill(boss);
+								return diaTick;
+							}
+
+							Attack.clear(40, 0, getLocaleString(locale), diaSort);
+							return diaTick;
 						}
 						return diaTick;
 					});
 				});
 			};
 
-		new Promise(resolve => diaTick && resolve()).then(function () { // All seals done; Time to go do dia
+		Config.Diablo.killDiablo && new Promise(resolve => diaTick && resolve()).then(function () { // All seals done; Time to go do dia
 			const PreAttack = require('PreAttack');
 			//Do dia
 			star.moveTo(); // go to star
@@ -98,7 +105,7 @@
 
 		if (!Config.Diablo.Follower) {
 			// Cast portal once in chaos
-			Config.Diablo.Entrance && new Promise(resolve => entrance.distance < 5 && resolve()).then(Pather.makePortal);
+			Config.Diablo.Entrance && !Config.Diablo.Fast && new Promise(resolve => entrance.distance < 5 && resolve()).then(Pather.makePortal);
 
 			// cast portal once close to star
 			new Promise(resolve => star.distance < 15 && resolve()).then(Pather.makePortal);
@@ -140,7 +147,7 @@
 
 			part('vizier', [sdk.units.DiabloSealVizierInactive, sdk.units.DiabloSealVizierActive], sdk.locale.monsters.GrandVizierOfChaos);
 			part('seiz', [sdk.units.DiabloSealSeizActive], sdk.locale.monsters.LordDeSeis);
-			part('infector', [sdk.units.DiabloSealInfectorInActive, sdk.units.DiabloSealInfectorActive], sdk.locale.monsters.InfectorOfSouls);
+			part('infector',  (type => Config.Diablo.Fast && type.reverse() || type)([sdk.units.DiabloSealInfectorInActive, sdk.units.DiabloSealInfectorActive]), sdk.locale.monsters.InfectorOfSouls);
 
 
 			parts.forEach(_ => _());
@@ -156,7 +163,7 @@
 		} finally { // Dont care for errors, just want to make sure the packet handler is removed after it
 			Messaging.send({Diablo: {done: true}});
 		}
-	}
+	};
 
 	Diablo.openSeal = function (seal) {
 		for (let i = 0; i < 5; i += 1) {

--- a/d2bs/kolbot/libs/bots/Diablo.js
+++ b/d2bs/kolbot/libs/bots/Diablo.js
@@ -114,10 +114,11 @@
 			Pather.useWaypoint(107);
 			Precast();
 		} else {
+			Town();
 			// town precast if possible, or go bo
 			!TownPrecast() && Precast.outTown();
 
-			Town();
+
 			Town.goToTown(4); // make sure we really are in act 4
 			Town.move("portalspot");
 			print('wait for portal');

--- a/d2bs/kolbot/libs/bots/RevPots.js
+++ b/d2bs/kolbot/libs/bots/RevPots.js
@@ -7,7 +7,7 @@ module.exports = function (Config, Attack, Pickit, Pather, Town, Misc) {
 	const GameData = require('GameData');
 	const Delta = new (require('Deltas'));
 	const Storage = require('Storage');
-	const excluded = [0, sdk.areas.MatronsDen,sdk.areas.FogottenSands,sdk.areas.FurnaceofPain,sdk.areas.UberTristram, sdk.areas.MaggotLairLvl1, sdk.areas.MaggotLairLvl2, sdk.areas.MaggotLairLvl3, sdk.areas.AncientsWay, sdk.areas.MooMooFarm];
+	const excluded = [0,sdk.areas.InnerCloister,sdk.areas.OuterCloister, sdk.areas.MatronsDen,sdk.areas.FogottenSands,sdk.areas.FurnaceofPain,sdk.areas.UberTristram, sdk.areas.MaggotLairLvl1, sdk.areas.MaggotLairLvl2, sdk.areas.MaggotLairLvl3, sdk.areas.AncientsWay, sdk.areas.MooMooFarm];
 
 	this.do = () => !done && GameData.AreaData
 		.filter(target => excluded.indexOf(target.Index) === -1)
@@ -17,7 +17,7 @@ module.exports = function (Config, Attack, Pickit, Pather, Town, Misc) {
 		.some(function (area) {
 			print('Going to area '+Object.keys(sdk.areas).find(key=>sdk.areas[key]===area.Index));
 			Pather.journeyTo(area.Index);
-			Attack.clearLevel({spectype: 0, quitWhen: () => done});
+			Attack.clearLevel({spectype: 0xF, quitWhen: () => done});
 			return done;
 		});
 

--- a/d2bs/kolbot/libs/bots/SpeedBaal.js
+++ b/d2bs/kolbot/libs/bots/SpeedBaal.js
@@ -333,7 +333,11 @@
 						//ToDo; do not get it during a wave;
 						Town.goToTown(sdk.areas.townOf(area));
 						Town.move('portalspot');
-						Pather.usePortal(area, null);
+						delay(500);
+						while(me.area !== area && Pather.getPortal(area, null)) {
+							Pather.usePortal(area, null);
+						}
+
 						let shrine = getUnits(2, "shrine").filter(shrine => shrine.mode === 0 && shrine.distance <= 20 && shrine.objtype === sdk.shrines.Experience).first();
 						shrine && Misc.getShrine(shrine);
 
@@ -341,7 +345,7 @@
 						Pather.useWaypoint(sdk.areas.PandemoniumFortress); // move to act 4.
 
 						if (data.diaTick) {
-							Pather.usePortal(sdk.areas.ChaosSanctuary);
+							Pather.usePortal(sdk.areas.ChaosSanctuary,null);
 							let diablo;
 							while (!(diablo = getUnit(1, sdk.monsters.Diablo1))) {
 								//ToDo; Writer some decent preattack for here
@@ -350,6 +354,7 @@
 							}
 
 							Attack.kill(sdk.monsters.Diablo1);
+							Pather.usePortal(sdk.areas.PandemoniumFortress,null);
 						}
 
 						preTown === 5 && tyrealAct5(); // use tyreal to go to act 5

--- a/d2bs/kolbot/libs/bots/SpeedBaal.js
+++ b/d2bs/kolbot/libs/bots/SpeedBaal.js
@@ -31,6 +31,12 @@
 		case 'loaded':
 		case 'started':
 			const SpeedBaal = function (Config, Attack, Pickit, Pather, Town, Misc) {
+				// Enforce the fact we have settings
+				const config = typeof Config.SpeedBaal === 'object' && Config.SpeedBaal || {};
+				if (!config.hasOwnProperty('Follower')) config.Follower = false;
+				if (!config.hasOwnProperty('Leecher')) config.Leecher = undefined;
+				if (!config.hasOwnProperty('Diablo')) config.Diablo = {};
+
 				const Precast = require('Precast');
 				const TownPrecast = require('TownPrecast');
 				const GameData = require('GameData');
@@ -78,7 +84,7 @@
 						}
 					};
 
-				this.toThrone = function () {
+				const toThrone = function () {
 					Town();
 					Config.FieldID && Town.fieldID();
 
@@ -128,7 +134,7 @@
 
 					// Wait for the portal
 					for (let i = 0, delayI = 10; i < 30 * (1000 / delayI); i += 1) {
-						if (config.Leecher && self.safe && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
+						if (config.Leecher && teamData.safe && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
 						if (!config.Leecher && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
 
 						delay(delayI);
@@ -151,7 +157,7 @@
 					return monster ? waves[waveMonsters.indexOf(monster.classid)] : 0;
 				};
 
-				this.waves = function () {
+				const waves = function () {
 					do {
 						self.wave = self.checkThrone();
 						self.wave && (self.nextWave = self.wave + 1);
@@ -214,7 +220,7 @@
 					return true;
 				};
 
-				this.baal = function () {
+				const killBaal = function () {
 					if ([sdk.areas.WorldstoneChamber, sdk.areas.ThroneOfDestruction].indexOf(me.area) === -1) {
 						// ToDo; magic to go to throne/WorldstoneChamber
 					}
@@ -255,13 +261,6 @@
 					delay(rand(1000, 2000));
 					return true;
 				};
-
-				// Set the settings
-				const config = typeof Config.SpeedBaal === 'object' && Config.SpeedBaal || {};
-				!config.hasOwnProperty('Follower') && (config.Follower = false);
-				!config.hasOwnProperty('OnWaveAttack') && (config.OnWaveAttack = undefined);
-				!config.hasOwnProperty('Leecher') && (config.Leecher = undefined);
-				!config.hasOwnProperty('Diablo') && (config.Diablo = {});
 
 				const build = new function () {
 					this.me = 0;
@@ -305,8 +304,7 @@
 					})();
 				};
 
-				me.switchWeapons(0); // make sure you wear gear on FIRST slot
-				[self.toThrone, self.waves, self.baal].some(item => !item());
+				[toThrone, waves, killBaal].some(item => !item());
 			};
 			module.exports = function (...args) {
 				try {

--- a/d2bs/kolbot/libs/bots/SpeedBaal.js
+++ b/d2bs/kolbot/libs/bots/SpeedBaal.js
@@ -46,17 +46,6 @@
 				const Delta = new (require('Deltas'));
 
 				const self = this,
-					getUnits = (...args) => {
-						let units = [], unit = getUnit.apply(undefined, args);
-
-						if (unit instanceof Unit) {
-							do {
-								unit && units.push(copyUnit(unit));
-							} while (unit.getNext());
-						}
-
-						return units;
-					},
 					/**
 					 * @param x
 					 * @param y

--- a/d2bs/kolbot/libs/bots/SpeedBaal.js
+++ b/d2bs/kolbot/libs/bots/SpeedBaal.js
@@ -38,7 +38,6 @@
 				if (!config.hasOwnProperty('ShrineFinder')) config.ShrineFinder = false;
 				if (!config.hasOwnProperty('ShrineTaker')) config.ShrineTaker = false;
 				if (!config.hasOwnProperty('Leecher')) config.Leecher = undefined;
-				if (!config.hasOwnProperty('Diablo')) config.Diablo = {};
 				if (!config.hasOwnProperty('DiabloClearer')) config.DiabloClearer = false;
 				if (!config.hasOwnProperty('DiabloKiller')) config.DiabloKiller = false;
 
@@ -429,3 +428,6 @@
 			}
 	}
 }).call(null, typeof module === 'object' && module || {}, typeof require === 'undefined' && (include('require.js') && require) || require);
+
+
+

--- a/d2bs/kolbot/libs/bots/SpeedBaal.js
+++ b/d2bs/kolbot/libs/bots/SpeedBaal.js
@@ -2,345 +2,341 @@
  * @description A baalrun made for speed, not for mf
  * @author Jaenster
  */
+(function (module, require) {
+	// const Messaging = require('Messaging');
+	// const Delta = new require('Deltas');
+	switch (getScript.startAsThread()) {
+		case 'thread':
+			let tick, oldtick, diaReady;
+			tick = oldtick = 0;
 
-function SpeedBaal(Config, Attack, Pickit, Pather, Town, Misc) {
-	const Precast = require('Precast');
-	const TownPrecast = require('TownPrecast');
-	const GameData = require('GameData');
-	const PreAttack = require('PreAttack');
-	const inGameChannel = require('Channel').inGame;
-	const Delta = new (require('Deltas'));
+			addEventListener('gamepacket', bytes => bytes
+				&& bytes.length
+				&& (
+					(
+						bytes[0] === 0xA4 // baal laughs
+						&& (tick = getTickCount())
+					) //|| (
+					// 	bytes[0] === 0x89 // All seals and monsters done
+					// 	&& (diaReady = true)
+					// )
+				) && false);
 
-	const self = this,
-		getUnits = (...args) => {
-			let units = [], unit = getUnit.apply(undefined, args);
 
-			if (unit instanceof Unit) {
-				do {
-					unit && units.push(copyUnit(unit));
-				} while (unit.getNext());
-			}
-
-			return units;
-		},
-		/**
-		 * @param x
-		 * @param y
-		 * @constructor
-		 */
-		Spot = function (x, y) {
-			this.x = x;
-			this.y = y;
-
-			this.clear = () => this.moveTo() && self.clear();
-			Object.defineProperty(this, 'distance', {
-				get: function () {
-					return getDistance.apply(null, [me, x, y]);
-				}
-			});
-		},
-		spots = {
-			throne: {
-				tp: new Spot(15083, 5035),
-				baal: new Spot(15089, 5011),
-				chamberPortal: new Spot(15089, 5006),
-				center: new Spot(15094, 5029),
-			},
-			worldstone: {
-				fastMove: new Spot(15144, 5892),
-				baalSpot: new Spot(15134, 5923)
-			}
-		};
-
-	this.toThrone = function () {
-		Town();
-		Config.FieldID && Town.fieldID();
-
-		// 2 ways to go to throne, either travel our self, or take an portal.
-		if (!config.Follower) {
-			let path = [[15112, 5206], [15111, 5175], [15112, 5141], [15109, 5107], [15113, 5073], [15083, 5035]];
-			TownPrecast();
-			// go to the throne
-			Pather.journeyTo(sdk.areas.ThroneOfDestruction);
-
-			// A predefined path is quicker as always calculating the path over and over again, this is the fastest route in throne ;)
-			path.forEach(args => Pather.moveTo.apply(Pather, args));
-
-			//ToDo; check if alone in game, if so, dont create a portal. Or, dont recast one if its up already
-			Pather.makePortal();
-
-			return me.area === sdk.areas.ThroneOfDestruction;
-		}
-
-		// Precast in town, or go bo outside of town and return to act 4
-		if (!(TownPrecast.can && TownPrecast())) {
-			Precast.outTown();
-			Pather.useWaypoint(sdk.areas.PandemoniumFortress);
-		}
-
-		// In case we in aren't in act < 4, go to act 4
-		me.area < sdk.areas.PandemoniumFortress && Town.goToTown(4); // Go to act 4.
-
-		if (me.area === sdk.areas.PandemoniumFortress) {
-			// in case we are in act 4.
-			Town.move("tyrael");
-			if (getUnit(2, sdk.units.RedPortalToAct5)) { // a red portal present?
-				Pather.useUnit(2, sdk.units.RedPortalToAct5, sdk.areas.Harrogath);
-			} else {
-				let tyrael = getUnit(1, "tyrael");
-
-				if (!tyrael || !tyrael.openMenu()) {
-					Town.goToTown(5); // Looks like we failed, lets go to act 5 by wp
-				} else {
-					Misc.useMenu(0x58D2); // Travel to Harrogath
+			while (me.ingame) {
+				delay(1000); // Just idle
+				if (tick !== oldtick) {
+					print('Baal laughed');
+					oldtick = tick;
+					delay(1000); // wait a while thanks to the magic of d2bs
+					scriptBroadcast({
+						baaltick: tick,
+					});
 				}
 			}
-		}
+			break;
+		case 'loaded':
+		case 'started':
+			module.exports = function (Config, Attack, Pickit, Pather, Town, Misc) {
+				const Precast = require('Precast');
+				const TownPrecast = require('TownPrecast');
+				const GameData = require('GameData');
+				const PreAttack = require('PreAttack');
+				const inGameChannel = require('Channel').inGame;
+				const Delta = new (require('Deltas'));
 
-		// If still not in town act 5, go to it and move to portal spot
-		Town.goToTown(5) && Town.move("portalspot");
+				const self = this,
+					getUnits = (...args) => {
+						let units = [], unit = getUnit.apply(undefined, args);
 
-		// Wait for the portal
-		for (let i = 0, delayI = 10; i < 30 * (1000 / delayI); i += 1) {
-			if (config.Leecher && self.safe && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
-			if (!config.Leecher && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
+						if (unit instanceof Unit) {
+							do {
+								unit && units.push(copyUnit(unit));
+							} while (unit.getNext());
+						}
 
-			delay(delayI);
-		}
+						return units;
+					},
+					/**
+					 * @param x
+					 * @param y
+					 * @constructor
+					 */
+					Spot = function (x, y) {
+						this.x = x;
+						this.y = y;
 
-		return me.area === sdk.areas.ThroneOfDestruction;
-	};
+						this.clear = () => this.moveTo() && self.clear();
+						Object.defineProperty(this, 'distance', {
+							get: function () {
+								return getDistance.apply(null, [me, x, y]);
+							}
+						});
+					},
+					spots = {
+						throne: {
+							tp: new Spot(15083, 5035),
+							baal: new Spot(15089, 5011),
+							chamberPortal: new Spot(15089, 5006),
+							center: new Spot(15094, 5029),
+						},
+						worldstone: {
+							fastMove: new Spot(15144, 5892),
+							baalSpot: new Spot(15134, 5923)
+						}
+					};
 
-	this.wave = 0;
-	this.nextWave = 1;
-	this.baaltick = 0;
-	this.safe = false;
+				this.toThrone = function () {
+					Town();
+					Config.FieldID && Town.fieldID();
 
-	inGameChannel.on('SpeedBaal', function (data) {
-		if (data.hasOwnProperty('safe')) {
-			self.safe = data.safe;
-		}
-	});
+					// 2 ways to go to throne, either travel our self, or take an portal.
+					if (!config.Follower) {
+						let path = [[15112, 5206], [15111, 5175], [15112, 5141], [15109, 5107], [15113, 5073], [15083, 5035]];
+						TownPrecast();
+						// go to the throne
+						Pather.journeyTo(sdk.areas.ThroneOfDestruction);
 
-	Delta.track(() => this.baaltick, () => this.nextWave === 1 && inGameChannel.send({SpeedBaal: {safe: true}}));
+						// A predefined path is quicker as always calculating the path over and over again, this is the fastest route in throne ;)
+						path.forEach(args => Pather.moveTo.apply(Pather, args));
 
-	this.checkThrone = function () {
-		let waveMonsters = [23, 62, 105, 381, 557, 558, 571], waves = [1, 1, 2, 2, 3, 4, 5],
-			monster = getUnits(1)
-				.filter(monster => monster.attackable && waveMonsters.indexOf(monster.classid) > -1)
-				.first();
+						//ToDo; check if alone in game, if so, dont create a portal. Or, dont recast one if its up already
+						Pather.makePortal();
 
-		return monster ? waves[waveMonsters.indexOf(monster.classid)] : 0;
-	};
+						return me.area === sdk.areas.ThroneOfDestruction;
+					}
 
-	this.waves = function () {
-		do {
-			self.wave = self.checkThrone();
-			self.wave && (self.nextWave = self.wave + 1);
+					// Precast in town, or go bo outside of town and return to act 4
+					if (!(TownPrecast.can && TownPrecast())) {
+						Precast.outTown();
+						Pather.useWaypoint(sdk.areas.PandemoniumFortress);
+					}
 
-			if (!self.wave) {
-				self.clear(); // First clear the throne
-				PreAttack.do([0, 23, 105, 557, 558, 571][self.nextWave], 12e3 - (getTickCount() - self.baaltick), spots.throne.center);
-			} else {
+					// In case we in aren't in act < 4, go to act 4
+					me.area < sdk.areas.PandemoniumFortress && Town.goToTown(4); // Go to act 4.
 
-				print('wave:' + self.wave);
-				// In a wave
-				self.clear(); // First clear the throne
-				self.afterWave();
-			}
+					if (me.area === sdk.areas.PandemoniumFortress) {
+						// in case we are in act 4.
+						Town.move("tyrael");
+						if (getUnit(2, sdk.units.RedPortalToAct5)) { // a red portal present?
+							Pather.useUnit(2, sdk.units.RedPortalToAct5, sdk.areas.Harrogath);
+						} else {
+							let tyrael = getUnit(1, "tyrael");
 
-			delay(10);
+							if (!tyrael || !tyrael.openMenu()) {
+								Town.goToTown(5); // Looks like we failed, lets go to act 5 by wp
+							} else {
+								Misc.useMenu(0x58D2); // Travel to Harrogath
+							}
+						}
+					}
 
-			// In case we moved to far from the throne's center
-			[15091, 5013].distance > 40 && !getUnit(1, sdk.units.BaalSitting) && [15092, 5041].moveTo();
+					// If still not in town act 5, go to it and move to portal spot
+					Town.goToTown(5) && Town.move("portalspot");
 
-			if (!getUnit(1, sdk.units.BaalSitting)) break;
-		} while (self.wave !== 5 || self.checkThrone());
+					// Wait for the portal
+					for (let i = 0, delayI = 10; i < 30 * (1000 / delayI); i += 1) {
+						if (config.Leecher && self.safe && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
+						if (!config.Leecher && Pather.usePortal(sdk.areas.ThroneOfDestruction, null)) break;
 
-		return true;
-	};
+						delay(delayI);
+					}
 
-	this.afterWave = function (wave) {
-		if (typeof Config.BossTraps !== 'undefined' && Array.isArray(Config.BossTraps) && Config.BossTraps.length) {
-			Config.UseFade && me.cast(258); // cast bos
+					return me.area === sdk.areas.ThroneOfDestruction;
+				};
 
-			Config.BossTraps.forEach((type, index) => me.cast(type, undefined, spots.throne.center.x - (Config.BossTraps.length / 2) + index, spots.throne.center.y - 10));
+				this.wave = 0;
+				this.nextWave = 1;
+				this.baaltick = 0;
+				this.safe = false;
 
-			Config.UseFade && me.cast(267); // cast fade
-		}
-
-		if (this.wave === 3) {
-			let hydra = getUnit(1, getLocaleString(3325));
-			!hydra && print('No hydra! <3');
-
-		}
-	};
-
-	this.clear = function (wave) {
-		const getUnits_filted = () => getUnits(1, -1)
-			.filter(unit => unit.hp > 0 && unit.attackable && spots.throne.center.distance < 40 && !checkCollision(me, unit, 0x0))
-			.filter(
-				unit => unit.x > 15070 && unit.x < 15120 // Between the x coords
-					&& unit.y > 5000 && unit.y < 5075 // And between the y coords
-			)
-			.sort((a, b) => GameData.monsterEffort(a, a.area).effort - GameData.monsterEffort(b, b.area).effort - ((b.distance - a.distance) / 5));
-
-		let units = getUnits_filted(), unit;
-		if (units) for (; (units = getUnits_filted()) && units.length;) {
-			delay(20);
-			if (!(unit = units.first())) break; // shouldn't happen but to be sure
-			for (let done = false; !done && unit.attackable;) {
-				done = !unit.attack();
-			}
-		}
-		return true;
-	};
-
-	this.baal = function () {
-		if ([sdk.areas.WorldstoneChamber, sdk.areas.ThroneOfDestruction].indexOf(me.area) === -1) {
-			// ToDo; magic to go to throne/WorldstoneChamber
-		}
-		Config.FieldID && Town.fieldID(); // perfect moment to have an empty inventory
-		if (me.area === sdk.areas.ThroneOfDestruction) {
-			// Go to WorldstoneChamber
-			Pather.moveTo(15089, 5006);
-			const baalSitting = !!getUnit(1, 543);
-
-			while (getUnit(1, 543) && delay(3)) ;
-
-			baalSitting && delay(1000); // Only a bit if baal wasnt there in the first place
-			me.area !== sdk.areas.WorldstoneChamber && Pather.usePortal(null, null, getUnit(2, 563));
-		}
-
-		if (me.area !== sdk.areas.WorldstoneChamber) {
-			throw Error('failed to go to the worldstone chamber');
-		}
-
-		switch (build.me) {
-			case build.warcry:
-			case build.convict:
-				clickParty(getParty(), 3); // leave party
-				break;
-			case build.curser:
-				let unit = getUnit(1, 544);
-				if (unit) {
-					print('cast lower curse on distance on baal');
-					me.cast(91, 0, 15166, 5903);
-				}
-				break;
-		}
-		// If we can teleport, move quickly over gap.
-		me.getSkill(43, 1) && spots.worldstone.fastMove.moveTo();
-		spots.worldstone.baalSpot.moveTo();
-		Attack.kill(544); // Baal
-		Pickit.pickItems();
-		delay(rand(1000, 2000));
-		return true;
-	};
-
-
-	if (!Array.prototype.first) {
-		Array.prototype.first = function () {
-			return this.length > 0 && this[0] || undefined;
-		};
-	}
-
-
-	addEventListener('scriptmsg', data => typeof data === 'object' && data.hasOwnProperty('baaltick') && (self.baaltick = data.baaltick));
-
-	// Set the settings
-	const config = typeof Config.SpeedBaal === 'object' && Config.SpeedBaal || {};
-	!config.hasOwnProperty('Follower') && (config.Follower = false);
-	!config.hasOwnProperty('OnWaveAttack') && (config.OnWaveAttack = undefined);
-	!config.hasOwnProperty('Leecher') && (config.Leecher = undefined);
-	!config.hasOwnProperty('Diablo') && (config.Diablo = {});
-
-	const build = new function () {
-		this.me = 0;
-		this.warcry = 1;
-		this.javazon = 2;
-		this.hammerdin = 3;
-		this.blizzard = 4;
-		this.convict = 5;
-		this.curser = 6;
-		this.firesorc = 7;
-		this.lightsorc = 8;
-		(() => {
-			const mostUsedSk = GameData.mostUsedSkills().filter(x => x.used > 10).map(x => x.skillId);
-			switch (true) {
-				case me.classid === sdk.charclass.Barbarian:
-					return (this.me = this.warcry);
-
-				case me.classid === sdk.charclass.Necromancer:
-					return (this.me = this.curser);
-
-				// If we have more as 5 hard points in conviction, pretty sure that is our goal
-				case me.getSkill(sdk.skills.Conviction, 0) > 5:
-					return (this.me = this.convict);
-
-				case [sdk.skills.BlessedHammer, sdk.skills.HolyBolt].some(sk => mostUsedSk.indexOf(sk) !== -1):
-					return (this.me = this.hammerdin);
-
-				case [sdk.skills.Meteor, sdk.skills.FireBall].some(sk => mostUsedSk.indexOf(sk) !== -1):
-					return (this.me = this.firesorc);
-
-				case [sdk.skills.Blizzard, sdk.skills.FrozenOrb, sdk.skills.IceBolt].some(sk => mostUsedSk.indexOf(sk) !== -1):
-					return (this.me = this.blizzard);
-
-				case [sdk.skills.ChargedStrike, sdk.skills.LightningFury, sdk.skills.LightningStrike].some(sk => mostUsedSk.indexOf(sk) !== -1):
-					return (this.me = this.javazon);
-
-				case [sdk.skills.Lightning, sdk.skills.ChainLightning].some(sk => mostUsedSk.indexOf(sk) !== -1):
-					return (this.me = this.lightsorc);
-			}
-			return null;
-		})();
-	};
-
-	me.switchWeapons(0); // make sure you wear gear on FIRST slot
-	try {
-		[self.toThrone, self.waves, self.baal].some(item => !item());
-	} finally {
-		Delta.destroy();
-	}
-}
-
-(function () {
-	let currentFile = 'libs/bots/SpeedBaal.js';
-
-	if (getScript(currentFile) && getScript(currentFile).name === getScript(true).name) {
-		let tick, oldtick;
-		tick = oldtick = 0;
-
-		// Running as a thread
-		addEventListener('gamepacket', bytes => bytes
-			&& bytes.length
-			&& (
-				(
-					bytes[0] === 0xA4 // baal laughs
-					&& (tick = getTickCount())
-				)
-				// || (
-				// 	bytes[0] === 0x89 // All seals and monsters done
-				// 	&& (diaReady = true)
-				// )
-			) && false);
-
-
-		// print('here');
-		while (me.ingame) {
-			delay(1000); // Just idle
-			if (tick !== oldtick) {
-				print('Baal laughed');
-				oldtick = tick;
-				delay(1000); // wait a while thanks to the magic of d2bs
-				scriptBroadcast({
-					baaltick: tick,
+				inGameChannel.on('SpeedBaal', function (data) {
+					if (data.hasOwnProperty('safe')) {
+						self.safe = data.safe;
+					}
 				});
-			}
-		}
-	} else {
-		// load the thread, if it isnt loaded yet
-		getScript(currentFile) || load(currentFile);
+
+				Delta.track(() => this.baaltick, () => this.nextWave === 1 && inGameChannel.send({SpeedBaal: {safe: true}}));
+
+				this.checkThrone = function () {
+					let waveMonsters = [23, 62, 105, 381, 557, 558, 571], waves = [1, 1, 2, 2, 3, 4, 5],
+						monster = getUnits(1)
+							.filter(monster => monster.attackable && waveMonsters.indexOf(monster.classid) > -1)
+							.first();
+
+					return monster ? waves[waveMonsters.indexOf(monster.classid)] : 0;
+				};
+
+				this.waves = function () {
+					do {
+						self.wave = self.checkThrone();
+						self.wave && (self.nextWave = self.wave + 1);
+
+						if (!self.wave) {
+							self.clear(); // First clear the throne
+							PreAttack.do([0, 23, 105, 557, 558, 571][self.nextWave], 12e3 - (getTickCount() - self.baaltick), spots.throne.center);
+						} else {
+
+							print('wave:' + self.wave);
+							// In a wave
+							self.clear(); // First clear the throne
+							self.afterWave();
+						}
+
+						delay(10);
+
+						// In case we moved to far from the throne's center
+						[15091, 5013].distance > 40 && !getUnit(1, sdk.units.BaalSitting) && [15092, 5041].moveTo();
+
+						if (!getUnit(1, sdk.units.BaalSitting)) break;
+					} while (self.wave !== 5 || self.checkThrone());
+
+					return true;
+				};
+
+				this.afterWave = function (wave) {
+					if (typeof Config.BossTraps !== 'undefined' && Array.isArray(Config.BossTraps) && Config.BossTraps.length) {
+						Config.UseFade && me.cast(258); // cast bos
+
+						Config.BossTraps.forEach((type, index) => me.cast(type, undefined, spots.throne.center.x - (Config.BossTraps.length / 2) + index, spots.throne.center.y - 10));
+
+						Config.UseFade && me.cast(267); // cast fade
+					}
+
+					if (this.wave === 3) {
+						let hydra = getUnit(1, getLocaleString(3325));
+						!hydra && print('No hydra! <3');
+
+					}
+				};
+
+				this.clear = function (wave) {
+					const getUnits_filted = () => getUnits(1, -1)
+						.filter(unit => unit.hp > 0 && unit.attackable && spots.throne.center.distance < 40 && !checkCollision(me, unit, 0x0))
+						.filter(
+							unit => unit.x > 15070 && unit.x < 15120 // Between the x coords
+								&& unit.y > 5000 && unit.y < 5075 // And between the y coords
+						)
+						.sort((a, b) => GameData.monsterEffort(a, a.area).effort - GameData.monsterEffort(b, b.area).effort - ((b.distance - a.distance) / 5));
+
+					let units = getUnits_filted(), unit;
+					if (units) for (; (units = getUnits_filted()) && units.length;) {
+						delay(20);
+						if (!(unit = units.first())) break; // shouldn't happen but to be sure
+						for (let done = false; !done && unit.attackable;) {
+							done = !unit.attack();
+						}
+					}
+					return true;
+				};
+
+				this.baal = function () {
+					if ([sdk.areas.WorldstoneChamber, sdk.areas.ThroneOfDestruction].indexOf(me.area) === -1) {
+						// ToDo; magic to go to throne/WorldstoneChamber
+					}
+					Config.FieldID && Town.fieldID(); // perfect moment to have an empty inventory
+					if (me.area === sdk.areas.ThroneOfDestruction) {
+						// Go to WorldstoneChamber
+						Pather.moveTo(15089, 5006);
+						const baalSitting = !!getUnit(1, 543);
+
+						while (getUnit(1, 543) && delay(3)) ;
+
+						baalSitting && delay(1000); // Only a bit if baal wasnt there in the first place
+						me.area !== sdk.areas.WorldstoneChamber && Pather.usePortal(null, null, getUnit(2, 563));
+					}
+
+					if (me.area !== sdk.areas.WorldstoneChamber) {
+						throw Error('failed to go to the worldstone chamber');
+					}
+
+					switch (build.me) {
+						case build.warcry:
+						case build.convict:
+							clickParty(getParty(), 3); // leave party
+							break;
+						case build.curser:
+							let unit = getUnit(1, 544);
+							if (unit) {
+								print('cast lower curse on distance on baal');
+								me.cast(91, 0, 15166, 5903);
+							}
+							break;
+					}
+					// If we can teleport, move quickly over gap.
+					me.getSkill(43, 1) && spots.worldstone.fastMove.moveTo();
+					spots.worldstone.baalSpot.moveTo();
+					Attack.kill(544); // Baal
+					Pickit.pickItems();
+					delay(rand(1000, 2000));
+					return true;
+				};
+
+
+				if (!Array.prototype.first) {
+					Array.prototype.first = function () {
+						return this.length > 0 && this[0] || undefined;
+					};
+				}
+
+
+				addEventListener('scriptmsg', data => typeof data === 'object' && data.hasOwnProperty('baaltick') && (self.baaltick = data.baaltick));
+
+				// Set the settings
+				const config = typeof Config.SpeedBaal === 'object' && Config.SpeedBaal || {};
+				!config.hasOwnProperty('Follower') && (config.Follower = false);
+				!config.hasOwnProperty('OnWaveAttack') && (config.OnWaveAttack = undefined);
+				!config.hasOwnProperty('Leecher') && (config.Leecher = undefined);
+				!config.hasOwnProperty('Diablo') && (config.Diablo = {});
+
+				const build = new function () {
+					this.me = 0;
+					this.warcry = 1;
+					this.javazon = 2;
+					this.hammerdin = 3;
+					this.blizzard = 4;
+					this.convict = 5;
+					this.curser = 6;
+					this.firesorc = 7;
+					this.lightsorc = 8;
+					(() => {
+						const mostUsedSk = GameData.mostUsedSkills().filter(x => x.used > 10).map(x => x.skillId);
+						switch (true) {
+							case me.classid === sdk.charclass.Barbarian:
+								return (this.me = this.warcry);
+
+							case me.classid === sdk.charclass.Necromancer:
+								return (this.me = this.curser);
+
+							// If we have more as 5 hard points in conviction, pretty sure that is our goal
+							case me.getSkill(sdk.skills.Conviction, 0) > 5:
+								return (this.me = this.convict);
+
+							case [sdk.skills.BlessedHammer, sdk.skills.HolyBolt].some(sk => mostUsedSk.indexOf(sk) !== -1):
+								return (this.me = this.hammerdin);
+
+							case [sdk.skills.Meteor, sdk.skills.FireBall].some(sk => mostUsedSk.indexOf(sk) !== -1):
+								return (this.me = this.firesorc);
+
+							case [sdk.skills.Blizzard, sdk.skills.FrozenOrb, sdk.skills.IceBolt].some(sk => mostUsedSk.indexOf(sk) !== -1):
+								return (this.me = this.blizzard);
+
+							case [sdk.skills.ChargedStrike, sdk.skills.LightningFury, sdk.skills.LightningStrike].some(sk => mostUsedSk.indexOf(sk) !== -1):
+								return (this.me = this.javazon);
+
+							case [sdk.skills.Lightning, sdk.skills.ChainLightning].some(sk => mostUsedSk.indexOf(sk) !== -1):
+								return (this.me = this.lightsorc);
+						}
+						return null;
+					})();
+				};
+
+				me.switchWeapons(0); // make sure you wear gear on FIRST slot
+				try {
+					[self.toThrone, self.waves, self.baal].some(item => !item());
+				} finally {
+					Delta.destroy();
+				}
+			};
 	}
-})();
+}).call(null, typeof module === 'object' && module || {}, typeof require === 'undefined' && (include('require.js') && require) || require);

--- a/d2bs/kolbot/libs/modules/Advertisement.js
+++ b/d2bs/kolbot/libs/modules/Advertisement.js
@@ -37,7 +37,7 @@
 				gamepassword: me.gamepassword,
 				diff: me.diff,
 				numberOfPlayers: (function (count = 0) {
-					if (me.gameReady && getParty()) for (let party = getParty(); party.getNext();) count++;
+					if (me.gameReady && getParty()) for (let party = getParty(); party && party.getNext();) count++;
 					return count;
 				}).call(),
 			}

--- a/d2bs/kolbot/libs/modules/Config.js
+++ b/d2bs/kolbot/libs/modules/Config.js
@@ -347,6 +347,7 @@
 		Fast: false,
 		Follower: false,
 		Entrance: true,
+		killDiablo: true,
 	};
 
 	Config.SpeedBaal = {

--- a/d2bs/kolbot/libs/modules/FastQuit.js
+++ b/d2bs/kolbot/libs/modules/FastQuit.js
@@ -7,6 +7,7 @@
 	const Message = require('Messaging');
 	switch (getScript.startAsThread()) {
 		case 'thread':
+			let startedInGame = me.inGame;
 			print('ÿc2Jaensterÿc0 :: Fast quit running');
 			const Worker = require('Worker');
 			let quitting = false;
@@ -21,8 +22,9 @@
 			Message.on('FastQuit', data => data.hasOwnProperty('act') && data.act && fastQuit());
 			addEventListener('gamepacketsent', bytes => bytes && bytes.length && bytes[0] === 0x69 && Worker.push(fastQuit) && false); // false to dont block the packet
 
-			while (!quitting) {
+			while (true) {
 				delay(3); // Just idle
+				if (startedInGame && quitting) break;
 			}
 			break;
 		case 'started':

--- a/d2bs/kolbot/libs/modules/FastQuit.js
+++ b/d2bs/kolbot/libs/modules/FastQuit.js
@@ -1,39 +1,31 @@
-// /**
-//  * @description Simple script that makes quiting a game allot more fast
-//  * @author Jaenster
-//  */
-// (function (global) { // Doesnt have return anything, it injects itself in global scope
-// 	!isIncluded('require.js') && include('require.js');
-// 	const Message = require('Messaging');
-// 	switch (getScript.startAsThread()) {
-// 		case 'thread':
-// 			print('ÿc2Jaensterÿc0 :: Fast quit running');
-// 			const Worker = require('Worker');
-// 			let quitting = false;
-// 			const fastQuit = function () {
-// 				if (quitting) return; // Somehow there is recursion
-//
-// 				quitting = true;
-// 				let Default = getScript('default.dbj');
-// 				Default && Default.stop();
-// 				print('fast quitting');
-// 				getScript(true).stop();
-// 			};
-//
-// 			Message.on('FastQuit', data => data.hasOwnProperty('act') && data.act && fastQuit());
-// 			addEventListener('gamepacketsent', bytes => bytes && bytes.length && bytes[0] === 0x69 && Worker.push(fastQuit) && false); // false to dont block the packet
-//
-// 			while (!quitting) {
-// 				delay(3); // Just idle
-// 			}
-// 			break;
-// 		case 'started':
-// 		case 'loaded':
-// 			const oldQuit = quit;
-// 			typeof global !== 'undefined' && (global.quit = function (reason) {
-// 				Message.send({FastQuit: {act: true, reason: reason}});
-// 				getScript(true).stop();
-// 				oldQuit();
-// 			});
-// 	}
-// })(this);
+/**
+ * @description Simple script that makes quiting a game allot more fast
+ * @author Jaenster
+ */
+(function (global) { // Doesnt have return anything, it injects itself in global scope
+	!isIncluded('require.js') && include('require.js');
+	const Message = require('Messaging');
+	switch (getScript.startAsThread()) {
+		case 'thread':
+			print('ÿc2Jaensterÿc0 :: Fast quit running');
+			const Worker = require('Worker');
+			let quitting = false;
+			const fastQuit = function () {
+				if (quitting) return; // Somehow there is recursion
+
+				quitting = true;
+				let Default = getScript('default.dbj');
+				Default && Default.pause(); // pause the default script so quitting game is faster
+			};
+
+			Message.on('FastQuit', data => data.hasOwnProperty('act') && data.act && fastQuit());
+			addEventListener('gamepacketsent', bytes => bytes && bytes.length && bytes[0] === 0x69 && Worker.push(fastQuit) && false); // false to dont block the packet
+
+			while (!quitting) {
+				delay(3); // Just idle
+			}
+			break;
+		case 'started':
+		case 'loaded':
+	}
+})(this);

--- a/d2bs/kolbot/libs/modules/FastQuit.js
+++ b/d2bs/kolbot/libs/modules/FastQuit.js
@@ -1,33 +1,33 @@
-/**
- * @description Simple script that makes quiting a game allot more fast
- * @author Jaenster
- */
-(function (global) { // Doesnt have return anything, it injects itself in global scope
-	!isIncluded('require.js') && include('require.js');
-	const Message = require('Messaging');
-	switch (getScript.startAsThread()) {
-		case 'thread':
-			let startedInGame = me.inGame;
-			print('ÿc2Jaensterÿc0 :: Fast quit running');
-			const Worker = require('Worker');
-			let quitting = false;
-			const fastQuit = function () {
-				if (quitting) return; // Somehow there is recursion
-
-				quitting = true;
-				let Default = getScript('default.dbj');
-				Default && Default.pause(); // pause the default script so quitting game is faster
-			};
-
-			Message.on('FastQuit', data => data.hasOwnProperty('act') && data.act && fastQuit());
-			addEventListener('gamepacketsent', bytes => bytes && bytes.length && bytes[0] === 0x69 && Worker.push(fastQuit) && false); // false to dont block the packet
-
-			while (true) {
-				delay(3); // Just idle
-				if (startedInGame && quitting) break;
-			}
-			break;
-		case 'started':
-		case 'loaded':
-	}
-})(this);
+// /**
+//  * @description Simple script that makes quiting a game allot more fast
+//  * @author Jaenster
+//  */
+// (function (global) { // Doesnt have return anything, it injects itself in global scope
+// 	!isIncluded('require.js') && include('require.js');
+// 	const Message = require('Messaging');
+// 	switch (getScript.startAsThread()) {
+// 		case 'thread':
+// 			let startedInGame = me.inGame;
+// 			print('ÿc2Jaensterÿc0 :: Fast quit running');
+// 			const Worker = require('Worker');
+// 			let quitting = false;
+// 			const fastQuit = function () {
+// 				if (quitting) return; // Somehow there is recursion
+//
+// 				quitting = true;
+// 				let Default = getScript('default.dbj');
+// 				Default && Default.pause(); // pause the default script so quitting game is faster
+// 			};
+//
+// 			Message.on('FastQuit', data => data.hasOwnProperty('act') && data.act && fastQuit());
+// 			addEventListener('gamepacketsent', bytes => bytes && bytes.length && bytes[0] === 0x69 && Worker.push(fastQuit) && false); // false to dont block the packet
+//
+// 			while (true) {
+// 				delay(3); // Just idle
+// 				if (startedInGame && quitting) break;
+// 			}
+// 			break;
+// 		case 'started':
+// 		case 'loaded':
+// 	}
+// })(this);

--- a/d2bs/kolbot/libs/modules/Pather.js
+++ b/d2bs/kolbot/libs/modules/Pather.js
@@ -913,8 +913,6 @@
 
 						delay(10);
 					}
-
-				Packet.flash(me.gid);
 			}
 
 			return false;

--- a/d2bs/kolbot/libs/modules/Pather.js
+++ b/d2bs/kolbot/libs/modules/Pather.js
@@ -1131,7 +1131,7 @@
 			area - the id of area to get the waypoint in
 			clearPath - clear path
 		*/
-		getWP: function (area, clearPath) {
+		getWP: function (area, clearPath,click=true) {
 			const Misc = require('Misc');
 			var i, j, wp, preset,
 				wpIDs = [119, 145, 156, 157, 237, 238, 288, 323, 324, 398, 402, 429, 494, 496, 511, 539];
@@ -1149,6 +1149,7 @@
 					wp = getUnit(2, "waypoint");
 
 					if (wp) {
+						if (!click) return true;
 						for (j = 0; j < 10; j += 1) {
 							Misc.click(0, 0, wp);
 							//wp.interact();

--- a/d2bs/kolbot/libs/modules/PreAttack.js
+++ b/d2bs/kolbot/libs/modules/PreAttack.js
@@ -30,7 +30,7 @@
             switch (true) {
                 case result.skill === sdk.skills.BlessedHammer:
                     doAttack = (estimated < 5e3);
-                    doAttack && me.setSkill(sdk.skills.Concentration, 1);
+                    doAttack && me.setSkill(sdk.skills.Concentration, 0);
                     break;
                 case result.skill === sdk.skills.Blizzard:
                     break;

--- a/d2bs/kolbot/libs/modules/Team.js
+++ b/d2bs/kolbot/libs/modules/Team.js
@@ -28,9 +28,10 @@
 			return others.forEach(other => sendCopyData(null, other.profile, mode || defaultCopyDataMode, JSON.stringify(what)))
 		},
 		broadcastInGame: (what, mode) => {
+			what.profile = me.windowtitle;
 			others.forEach(function (other) {
 				for (const party = getParty(); party && party.getNext();) {
-					typeof party === 'object' && party && party.hasOwnProperty('name') && party.name === other.name && Team.send(other.profile, what, mode);
+					typeof party === 'object' && party && party.hasOwnProperty('name') && party.name === other.name && sendCopyData(null, other.profile, mode || defaultCopyDataMode, JSON.stringify(what));
 				}
 			})
 		}

--- a/d2bs/kolbot/libs/sdk.js
+++ b/d2bs/kolbot/libs/sdk.js
@@ -152,22 +152,20 @@ let sdk = {
         FurnaceofPain: 135,
         UberTristram: 136,
 
-		town: new Proxy({}, {
-			get: function (area) {
-				switch (true) {
-					case area < sdk.areas.LutGholein:
-						return 1;
-					case area < sdk.areas.LowerKurast:
-						return 2;
-					case area < sdk.areas.PandemoniumFortress:
-						return 3;
-					case area < sdk.areas.Harrogath:
-						return 4;
-					default:
-						return 5;
-				}
-			}
-		}),
+        townOf: function (area) {
+            switch (true) {
+                case area < sdk.areas.LutGholein:
+                    return 1;
+                case area < sdk.areas.LowerKurast:
+                    return 2;
+                case area < sdk.areas.PandemoniumFortress:
+                    return 3;
+                case area < sdk.areas.Harrogath:
+                    return 4;
+                default:
+                    return 5;
+            }
+        }
     },
 
     skills: {

--- a/d2bs/kolbot/libs/sdk.js
+++ b/d2bs/kolbot/libs/sdk.js
@@ -150,7 +150,24 @@ let sdk = {
         MatronsDen: 133,
         FogottenSands: 134,
         FurnaceofPain: 135,
-        UberTristram: 136
+        UberTristram: 136,
+
+		town: new Proxy({}, {
+			get: function (area) {
+				switch (true) {
+					case area < sdk.areas.LutGholein:
+						return 1;
+					case area < sdk.areas.LowerKurast:
+						return 2;
+					case area < sdk.areas.PandemoniumFortress:
+						return 3;
+					case area < sdk.areas.Harrogath:
+						return 4;
+					default:
+						return 5;
+				}
+			}
+		}),
     },
 
     skills: {


### PR DESCRIPTION
- Added the ability to make a char search for a shrine
- Added the ability to take a shrine that someone else searched
- Added the ability to make a char clear Diablo
- Added the ability to kill Diablo while someone else cleared it
- Those 2 abilities are in sync with eachother. It goes for shrine/dia if you do both, at the same time (so shrined dia kill).
- Fix'd team script (Team.broadcastInGame
- Broke and fixed FastQuit (no changes)
- Fix'd normal/nightmare games TCP/IP
- Removed Packet.flash as it isnt working
- Respect the configuration of Diablo better

New configurations:
```javascript
Config.SpeedBaal.ShrineFinder = true; // Searches for a shrine
Config.SpeedBaal.ShrineTaker = true; // Takes a shrine from someone that search it (can be the searcher too)
Config.SpeedBaal.DiabloClearer = true; // Clears diablo, but not kill him
Config.SpeedBaal.DiabloKiller = true; // Kill Diablo once he is cleared
```